### PR TITLE
misc: update olares installation steps and add activation note

### DIFF
--- a/docs/manual/get-started/activate-olares.md
+++ b/docs/manual/get-started/activate-olares.md
@@ -15,7 +15,7 @@ Use the Wizard URL and initial one-time password to activate. This process conne
 
    a. Open LarePass app, and tap **Scan QR code** to scan the QR code on the Wizard page and complete the activation.
    :::warning Same network required
-   To avoid scanning failures, ensure that both your phone and the Olares device are connected to the same network.
+   To avoid activation failures, ensure that both your phone and the Olares device are connected to the same network.
    :::
    ![Activate Olares](/images/manual/get-started/activate-olares.png)
    b. Reset the login password for Olares by following the on-screen instructions on LarePass.

--- a/docs/manual/get-started/activate-olares.md
+++ b/docs/manual/get-started/activate-olares.md
@@ -14,6 +14,9 @@ Use the Wizard URL and initial one-time password to activate. This process conne
 5. Activate Olares using LarePass app.
 
    a. Open LarePass app, and tap **Scan QR code** to scan the QR code on the Wizard page and complete the activation.
+   :::warning Same network required
+   To avoid scanning failures, ensure that both your phone and the Olares device are connected to the same network.
+   :::
    ![Activate Olares](/images/manual/get-started/activate-olares.png)
    b. Reset the login password for Olares by following the on-screen instructions on LarePass.
 

--- a/docs/manual/get-started/install-olares-linux.md
+++ b/docs/manual/get-started/install-olares-linux.md
@@ -13,28 +13,6 @@ Make sure your Linux device meets the following requirements.
   - Ubuntu 22.04 LTS or later
   - Debian 11 or later
 
-## Set up system environment
-
-1. Bind your local IP to your Ubuntu hostname for stable DNS resolution:
-
-   ```bash
-   sudo apt install net-tools
-   ifconfig
-   # Get your local IP. Make sure it starts with `192.168`.
-   ```
-
-   ```bash {2}
-   sudo nano /etc/hosts
-   192.168.xx.xx   linux  # Add this line
-   # Replace with your actual local IP and your host name.
-   ```
-
-2. Reboot your Ubuntu to apply the change.
-
-   ```bash
-   sudo reboot
-   ```
-
 ## Install Olares
 
 Run the following command:


### PR DESCRIPTION
This PR:
- updates Olares installation on linux by removing ip binding procedure
- adds a same network required note for Olares device and phone during activation