### PR TITLE
fix: broken relative links in FilterableList

### DIFF
--- a/docs/manual/use-cases/index.md
+++ b/docs/manual/use-cases/index.md
@@ -2,13 +2,13 @@
 While other guides tell you "what" and "how," these use cases reveal the full potential of Olares - from running AI models to creating seamless workflows across your self-hosted services.
 
 <FilterableList :items="[
-  { title: 'Stable Diffusion', link: './stable-diffusion', tags: ['ai'] },
-  { title: 'ComfyUI', link: './comfyui', tags: ['ai'] },
-  { title: 'Open WebUI', link: './openwebui', tags: ['ai'] },
-  { title: 'Perplexica', link: './perplexica', tags: ['ai']},
-  { title: 'Dify', link: './dify', tags: ['ai']},
-  { title: 'Hubble', link: 'https://jointerminus.medium.com/running-farcaster-hubble-on-your-home-cloud-with-terminus-756f982c82dd', tags: ['social network']},
-  { title: 'Use ComfyUI in Krita', link: './comfyui-for-krita', tags: ['ai']},
-  { title: 'Stream media library', link: './stream-media', tags: ['entertainment']},
+  { title: 'Stable Diffusion', link: 'stable-diffusion', tags: ['ai'] },
+  { title: 'ComfyUI', link: 'comfyui', tags: ['ai'] },
+  { title: 'Open WebUI', link: 'openwebui', tags: ['ai'] },
+  { title: 'Perplexica', link: 'perplexica', tags: ['ai']},
+  { title: 'Dify', link: 'dify', tags: ['ai']},
+  { title: 'Hubble', link: 'https://blog.olares.xyz/running-farcaster-hubble-on-your-home-cloud/', tags: ['social network']},
+  { title: 'Use ComfyUI in Krita.md', link: 'comfyui-for-krita', tags: ['ai']},
+  { title: 'Stream media library.md', link: 'stream-media', tags: ['entertainment']},
 ]" 
 />

--- a/docs/manual/use-cases/index.md
+++ b/docs/manual/use-cases/index.md
@@ -2,13 +2,13 @@
 While other guides tell you "what" and "how," these use cases reveal the full potential of Olares - from running AI models to creating seamless workflows across your self-hosted services.
 
 <FilterableList :items="[
-  { title: 'Stable Diffusion', link: 'stable-diffusion', tags: ['ai'] },
-  { title: 'ComfyUI', link: 'comfyui', tags: ['ai'] },
-  { title: 'Open WebUI', link: 'openwebui', tags: ['ai'] },
-  { title: 'Perplexica', link: 'perplexica', tags: ['ai']},
-  { title: 'Dify', link: 'dify', tags: ['ai']},
+  { title: 'Stable Diffusion', link: './stable-diffusion.html', tags: ['ai'] },
+  { title: 'ComfyUI', link: './comfyui.html', tags: ['ai'] },
+  { title: 'Open WebUI', link: './openwebui.html', tags: ['ai'] },
+  { title: 'Perplexica', link: './perplexica.html', tags: ['ai']},
+  { title: 'Dify', link: './dify.html', tags: ['ai']},
   { title: 'Hubble', link: 'https://blog.olares.xyz/running-farcaster-hubble-on-your-home-cloud/', tags: ['social network']},
-  { title: 'Use ComfyUI in Krita.md', link: 'comfyui-for-krita', tags: ['ai']},
-  { title: 'Stream media library.md', link: 'stream-media', tags: ['entertainment']},
+  { title: 'Use ComfyUI in Krita', link: './comfyui-for-krita.html', tags: ['ai']},
+  { title: 'Stream media library', link: './stream-media.html', tags: ['entertainment']},
 ]" 
 />

--- a/docs/zh/manual/use-cases/index.md
+++ b/docs/zh/manual/use-cases/index.md
@@ -2,12 +2,12 @@
 通过这些典型场景的操作指南，了解如何用 Olares 搭建 AI 应用、自托管服务等，快速实现你的具体需求。
 
 <FilterableList :items="[
-  { title: 'Stable Diffusion', link: 'stable-diffusion', tags: ['AI'] },
-  { title: 'ComfyUI', link: 'comfyui', tags: ['AI'] },
-  { title: 'Open WebUI', link: 'openwebui', tags: ['AI'] },
-  { title: 'Perplexica', link: 'perplexica', tags: ['AI']},
-  { title: 'Dify', link: 'dify', tags: ['AI']},
-  { title: '在 Krita 中使用 ComfyUI', link: 'comfyui-for-krita', tags: ['AI']},
-  { title: '远程看视频', link: 'stream-media', tags: ['娱乐']},
+  { title: 'Stable Diffusion', link: './stable-diffusion.html', tags: ['AI'] },
+  { title: 'ComfyUI', link: './comfyui.html', tags: ['AI'] },
+  { title: 'Open WebUI', link: './openwebui.html', tags: ['AI'] },
+  { title: 'Perplexica', link: './perplexica.html', tags: ['AI']},
+  { title: 'Dify', link: './dify.html', tags: ['AI']},
+  { title: '在 Krita 中使用 ComfyUI', link: './comfyui-for-krita.html', tags: ['AI']},
+  { title: '远程看视频', link: './stream-media.html', tags: ['娱乐']},
 ]" 
 />

--- a/docs/zh/manual/use-cases/index.md
+++ b/docs/zh/manual/use-cases/index.md
@@ -2,12 +2,12 @@
 通过这些典型场景的操作指南，了解如何用 Olares 搭建 AI 应用、自托管服务等，快速实现你的具体需求。
 
 <FilterableList :items="[
-  { title: 'Stable Diffusion', link: './stable-diffusion', tags: ['AI'] },
-  { title: 'ComfyUI', link: './comfyui', tags: ['AI'] },
-  { title: 'Open WebUI', link: './openwebui', tags: ['AI'] },
-  { title: 'Perplexica', link: './perplexica', tags: ['AI']},
-  { title: 'Dify', link: './dify', tags: ['AI']},
-  { title: '在 Krita 中使用 ComfyUI', link: './comfyui-for-krita', tags: ['AI']},
-  { title: '流媒体库', link: './stream-media', tags: ['娱乐']},
+  { title: 'Stable Diffusion', link: 'stable-diffusion', tags: ['AI'] },
+  { title: 'ComfyUI', link: 'comfyui', tags: ['AI'] },
+  { title: 'Open WebUI', link: 'openwebui', tags: ['AI'] },
+  { title: 'Perplexica', link: 'perplexica', tags: ['AI']},
+  { title: 'Dify', link: 'dify', tags: ['AI']},
+  { title: '在 Krita 中使用 ComfyUI', link: 'comfyui-for-krita', tags: ['AI']},
+  { title: '远程看视频', link: 'stream-media', tags: ['娱乐']},
 ]" 
 />


### PR DESCRIPTION
### Issues
Relative links like `'./stable-diffusion'` in the `FilterableList` component were rendering incorrectly in production. In the production environment, these links failed to resolve correctly, leading to broken navigation or blank pages.
### What’s changed
This PR updates the links in the `FilterableList` to use paths with `.html` extension.