### PR TITLE
feat: add firewall rules setting and select storage path content

### DIFF
--- a/docs/manual/get-started/install-olares-windows.md
+++ b/docs/manual/get-started/install-olares-windows.md
@@ -89,7 +89,7 @@ Make sure your Windows meets the following requirements.
    C:\  Free Disk: 391.07 GB
    D:\  Free Disk: 281.32 GB
    
-   Please enter the drive letter (e.g., C or D):
+   Please enter the drive letter (e.g., C):
    ```
 :::tip Root user password
 During the installation, you may be prompted to enter your root password.

--- a/docs/zh/manual/get-started/install-olares-windows.md
+++ b/docs/zh/manual/get-started/install-olares-windows.md
@@ -88,7 +88,7 @@ Windows 设备需满足以下条件：
    C:\  Free Disk: 391.07 GB
    D:\  Free Disk: 281.32 GB
    
-   Please enter the drive letter (e.g., C or D):
+   Please enter the drive letter (e.g., C):
    ```
 :::tip root 用户密码
 安装过程中，可能需要输入 root 用户密码。


### PR DESCRIPTION
This PR: 
- Explains how to set up firewall rules during the installation process. (Originally written in https://github.com/beclab/docs/pull/95)
- Adds a step that asks users to select the drive letter for WSL Ubuntu Distro.